### PR TITLE
RAM-backed small-file cache with auto-flush; mount without PUT-Range; cache_threshold option; robust unmount

### DIFF
--- a/DAV-requirements.md
+++ b/DAV-requirements.md
@@ -25,9 +25,8 @@ Renaming files, creating directories, removing files/directories
 ## For writing files.
 
 Writing files is a delicate operation, we should take care to do it
-correctly. Right now, the driver checks if we're talking to an Apache
-or SabreDAV implementation because they are the only ones that implement
-partial put.
+correctly. The driver checks if we're talking to an Apache or SabreDAV
+implementation because they are the only ones that implement partial updates.
 
 - If-Match: * / If-None-Match: * support (RFC2616).  
   If-Match: * is used with the PUT method to prevent files being written
@@ -36,13 +35,19 @@ partial put.
   if it already exists.  
   Though this is very basic, there are servers that do not implement this,
   or not correctly.
-- Partial PUT support.  
+- Partial PUT support (preferred).  
   This means writing just a part of a file, updating it in-place, instead
-  of replacing an existing file. webdavFS detects what webserver it is
-  talking  to. If it's Apache it uses PUT + Content-Range, if it's
+  of replacing an existing file. webdavfs detects what webserver it is
+  talking to. If it's Apache it uses PUT + Content-Range, if it's
   SabreDAV it uses PATCH + X-Update-Range. For more info, see:  
   https://blog.sphere.chronosempire.org.uk/2012/11/21/webdav-and-the-http-patch-nightmare  
   http://sabre.io/dav/http-patch/  
+
+- Fallback: full PUT on close.  
+  If partial PUT is not available, webdavfs supports read–write by using a
+  per‑open in‑RAM buffer. The full file is uploaded with a normal PUT on
+  fsync/close or after a short inactivity period. Servers only need to support
+  standard `PUT`, `GET`, and conditional `If-Match`/`If-None-Match`.
 
 ## Partial PUT support as a standard
 

--- a/cache.go
+++ b/cache.go
@@ -9,7 +9,6 @@ func (nd *Node) statInfoFresh() bool {
 	return nd.LastStat.Add(statCacheTime).After(now)
 }
 
-func (nd* Node) statInfoTouch() {
+func (nd *Node) statInfoTouch() {
 	nd.LastStat = time.Now()
 }
-

--- a/daemon.go
+++ b/daemon.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -83,8 +82,8 @@ func Daemonize() error {
 
 	// now re-exec ourselves.
 	attrs := os.ProcAttr{
-		Files: []*os.File{ devnull, wout, werr },
-		Sys: &syscall.SysProcAttr{ Setsid: true },
+		Files: []*os.File{devnull, wout, werr},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
 	}
 	os.Setenv(isDaemonEnv, "YES")
 	proc, err := os.StartProcess(binary, os.Args, &attrs)
@@ -126,7 +125,7 @@ func Daemonize() error {
 }
 
 // Returns true when this process is a daemonized child.
-func IsDaemon() (bool) {
+func IsDaemon() bool {
 	return os.Getenv(isDaemonEnv) != ""
 }
 
@@ -141,4 +140,3 @@ func Detach() error {
 	fh.Close()
 	return nil
 }
-

--- a/debug.go
+++ b/debug.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -8,7 +7,8 @@ import (
 )
 
 var dbgChan = make(chan string, 8)
-func init () {
+
+func init() {
 	go func() {
 		for {
 			line := <-dbgChan
@@ -28,4 +28,3 @@ func dbgJson(obj interface{}) string {
 	}
 	return fmt.Sprintf("%+v", obj)
 }
-

--- a/main.go
+++ b/main.go
@@ -199,6 +199,12 @@ func main() {
 	}
 	config.Mode = mountOpts.Mode
 
+	// Default cache threshold: 64 MiB if not configured
+	if mountOpts.CacheThreshold == 0 {
+		mountOpts.CacheThreshold = 64 * 1024 * 1024
+	}
+	config.CacheThreshold = mountOpts.CacheThreshold
+
 	// if running from fstab with "uid=123,gid=456" set some reasonable
 	// defaults so that that uid can actually access the files.
 	if os.Getuid() == 0 && mountOpts.Uid != 0 && mountOpts.Mode == 0 {

--- a/memhandle.go
+++ b/memhandle.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"bazil.org/fuse"
+	"golang.org/x/net/context"
+)
+
+// MemHandle provides a per-open-file in-RAM buffer for servers
+// without PUT Range support. It loads the full file on open and
+// flushes back with a single PUT on close if modified.
+type MemHandle struct {
+	n        *Node
+	buf      []byte
+	dirty    bool
+	writable bool
+	mu       sync.Mutex
+	timer    *time.Timer
+	closed   bool
+	flushing bool
+}
+
+func newMemHandle(n *Node, initial []byte, writable bool) *MemHandle {
+	mh := &MemHandle{n: n, buf: initial, dirty: false, writable: writable}
+	// Update node size from buffer for consistency.
+	n.Lock()
+	n.Size = uint64(len(mh.buf))
+	n.OpenMem = append(n.OpenMem, mh)
+	n.Unlock()
+	return mh
+}
+
+// Read reads from the in-memory buffer.
+func (h *MemHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.n.incIoRef(req.Header.ID)
+	defer h.n.decIoRef()
+
+	off := req.Offset
+	if off >= int64(len(h.buf)) {
+		resp.Data = []byte{}
+		return nil
+	}
+	// compute slice bounds
+	end := off + int64(req.Size)
+	if end > int64(len(h.buf)) {
+		end = int64(len(h.buf))
+	}
+	resp.Data = h.buf[off:end]
+	return nil
+}
+
+// Write writes into the in-memory buffer and marks it dirty.
+func (h *MemHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
+	if !h.writable {
+		return fuse.EPERM
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.n.incIoRef(req.Header.ID)
+	defer h.n.decIoRef()
+
+	// Ensure buffer is large enough
+	need := int(req.Offset) + len(req.Data)
+	if need > len(h.buf) {
+		// grow and zero-fill new region
+		nb := make([]byte, need)
+		copy(nb, h.buf)
+		h.buf = nb
+	}
+	copy(h.buf[int(req.Offset):int(req.Offset)+len(req.Data)], req.Data)
+	h.dirty = true
+	h.scheduleFlushLocked()
+	resp.Size = len(req.Data)
+
+	// Update node size
+	h.n.Lock()
+	if uint64(need) > h.n.Size {
+		h.n.Size = uint64(need)
+	}
+	h.n.Unlock()
+	return nil
+}
+
+// Release flushes the buffer back to the server on close if dirty.
+func (h *MemHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
+	h.mu.Lock()
+	h.closed = true
+	if h.timer != nil {
+		h.timer.Stop()
+		h.timer = nil
+	}
+	defer h.mu.Unlock()
+	// If not dirty, nothing to do.
+	if !h.dirty || h.n.Deleted {
+		return nil
+	}
+
+	h.n.incIoRef(req.Header.ID)
+	path := h.n.getPath()
+	// send full PUT with entire buffer
+	// If the file does not exist remotely, create it on first upload.
+	_, err := dav.Put(path, h.buf, !h.n.RemoteExists, false)
+	h.n.decIoRef()
+	if err != nil {
+		return err
+	}
+
+	// Refresh node metadata afterwards (best effort)
+	dnode, err2 := dav.Stat(path)
+	h.n.Lock()
+	if err2 == nil {
+		h.n.Dnode = dnode
+		h.n.Mtime = dnode.Mtime
+		h.n.Ctime = dnode.Ctime
+		h.n.Size = dnode.Size
+		h.n.RemoteExists = true
+	} else {
+		// at least touch mtime
+		h.n.Mtime = time.Now()
+	}
+	// remove from open list
+	for i, mh := range h.n.OpenMem {
+		if mh == h {
+			h.n.OpenMem = append(h.n.OpenMem[:i], h.n.OpenMem[i+1:]...)
+			break
+		}
+	}
+	h.n.Unlock()
+	return nil
+}
+
+// Flush pushes data like Release but keeps the handle open.
+func (h *MemHandle) Flush(ctx context.Context, req *fuse.FlushRequest) error {
+	h.mu.Lock()
+	if h.timer != nil {
+		h.timer.Stop()
+	}
+	defer h.mu.Unlock()
+	if !h.dirty {
+		return nil
+	}
+	h.n.incIoRef(req.Header.ID)
+	path := h.n.getPath()
+	_, err := dav.Put(path, h.buf, !h.n.RemoteExists, false)
+	h.n.decIoRef()
+	if err != nil {
+		return err
+	}
+	h.dirty = false
+	h.n.Lock()
+	h.n.RemoteExists = true
+	h.n.Unlock()
+	return nil
+}
+
+// Fsync also flushes to remote.
+func (h *MemHandle) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
+	h.mu.Lock()
+	if h.timer != nil {
+		h.timer.Stop()
+	}
+	defer h.mu.Unlock()
+	if !h.dirty {
+		return nil
+	}
+	h.n.incIoRef(req.Header.ID)
+	path := h.n.getPath()
+	_, err := dav.Put(path, h.buf, !h.n.RemoteExists, false)
+	h.n.decIoRef()
+	if err != nil {
+		return err
+	}
+	h.dirty = false
+	h.n.Lock()
+	h.n.RemoteExists = true
+	h.n.Unlock()
+	return nil
+}
+
+// resize adjusts the in-memory buffer size.
+func (h *MemHandle) resize(newSize uint64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cur := uint64(len(h.buf))
+	if newSize == cur {
+		return
+	}
+	if newSize < cur {
+		h.buf = h.buf[:newSize]
+	} else {
+		nb := make([]byte, newSize)
+		copy(nb, h.buf)
+		h.buf = nb
+	}
+	h.dirty = true
+	h.scheduleFlushLocked()
+}
+
+// scheduleFlushLocked (re)arms the inactivity timer. Caller must hold h.mu.
+func (h *MemHandle) scheduleFlushLocked() {
+	if h.closed {
+		return
+	}
+	if h.timer == nil {
+		h.timer = time.AfterFunc(10*time.Second, func() {
+			h.inactivityFlush()
+		})
+	} else {
+		h.timer.Reset(10 * time.Second)
+	}
+}
+
+// inactivityFlush performs a flush after the inactivity window if needed.
+func (h *MemHandle) inactivityFlush() {
+	h.mu.Lock()
+	if h.closed || !h.dirty || h.flushing {
+		h.mu.Unlock()
+		return
+	}
+	h.flushing = true
+	data := make([]byte, len(h.buf))
+	copy(data, h.buf)
+	create := !h.n.RemoteExists
+	// optimistic clear; if new writes happen, dirty will be set again.
+	h.dirty = false
+	h.mu.Unlock()
+
+	path := h.n.getPath()
+	// background flush; no specific RequestID
+	_, err := dav.Put(path, data, create, false)
+
+	h.mu.Lock()
+	h.flushing = false
+	if err != nil {
+		// mark dirty again to retry later
+		h.dirty = true
+		// leave timer nil so a future write will rearm; or rearm now
+		h.scheduleFlushLocked()
+		h.mu.Unlock()
+		return
+	}
+	// success: mark remote existence
+	h.n.Lock()
+	h.n.RemoteExists = true
+	h.n.Unlock()
+	h.mu.Unlock()
+}
+
+// ReadAll allows cat-like reads to fetch the full buffer efficiently.
+func (h *MemHandle) ReadAll(ctx context.Context) ([]byte, error) {
+	// Provide a copy to avoid exposing internal buffer to mutation
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cp := make([]byte, len(h.buf))
+	copy(cp, h.buf)
+	return cp, nil
+}

--- a/mountoptions.go
+++ b/mountoptions.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -8,28 +7,29 @@ import (
 )
 
 type MountOptions struct {
-	AllowRoot		bool
-	AllowOther		bool
-	DefaultPermissions	bool
-	NoDefaultPermissions	bool
-	ReadOnly		bool
-	ReadWrite		bool
-	ReadWriteDirOps		bool
-	Uid			uint32
-	Gid			uint32
-	Mode			uint32
-	Cookie			string
-	Password		string
-	Username		string
-	AsyncRead		bool
-	NonEmpty		bool
-	MaxConns		uint32
-	MaxIdleConns		uint32
-	SabreDavPartialUpdate	bool
+	AllowRoot             bool
+	AllowOther            bool
+	DefaultPermissions    bool
+	NoDefaultPermissions  bool
+	ReadOnly              bool
+	ReadWrite             bool
+	ReadWriteDirOps       bool
+	Uid                   uint32
+	Gid                   uint32
+	Mode                  uint32
+	Cookie                string
+	Password              string
+	Username              string
+	AsyncRead             bool
+	NonEmpty              bool
+	MaxConns              uint32
+	MaxIdleConns          uint32
+	SabreDavPartialUpdate bool
+	CacheThreshold        uint64 // bytes; 0 => default
 }
 
 func parseUInt32(v string, base int, name string, loc *uint32) (err error) {
-	n, err := strconv.ParseUint(v , base, 32)
+	n, err := strconv.ParseUint(v, base, 32)
 	if err == nil {
 		*loc = uint32(n)
 	}
@@ -84,6 +84,23 @@ func parseMountOptions(n string, sloppy bool) (mo MountOptions, err error) {
 			err = parseUInt32(v, 10, "maxidleconns", &mo.MaxIdleConns)
 		case "sabredav_partialupdate":
 			mo.SabreDavPartialUpdate = true
+		case "cache_threshold":
+			// bytes
+			var v64 uint64
+			v64, err = strconv.ParseUint(v, 10, 64)
+			if err == nil {
+				mo.CacheThreshold = v64
+			}
+		case "cache_threshold_mb":
+			// megabytes
+			var v64 uint64
+			v64u32, err2 := strconv.ParseUint(v, 10, 32)
+			if err2 == nil {
+				v64 = uint64(v64u32) * 1024 * 1024
+				mo.CacheThreshold = v64
+			} else {
+				err = err2
+			}
 		default:
 			if !sloppy {
 				err = errors.New(a[0] + ": unknown option")

--- a/osdep_default.go
+++ b/osdep_default.go
@@ -1,12 +1,12 @@
+//go:build !linux
 // +build !linux
 
 package main
 
 import (
-        "syscall"
+	"syscall"
 )
 
 func Dup2(oldfd int, newfd int) (err error) {
 	return syscall.Dup2(oldfd, newfd)
 }
-

--- a/osdep_linux.go
+++ b/osdep_linux.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-        "syscall"
+	"syscall"
 )
 
 func Dup2(oldfd int, newfd int) (err error) {
 	return syscall.Dup3(oldfd, newfd, 0)
 }
-

--- a/trace.go
+++ b/trace.go
@@ -1,12 +1,11 @@
-
 package main
 
 import (
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -15,7 +14,7 @@ import (
 )
 
 const (
-	T_WEBDAV	= 1 << iota
+	T_WEBDAV = 1 << iota
 	T_HTTP_REQUEST
 	T_HTTP_HEADERS
 	T_FUSE
@@ -28,7 +27,7 @@ var traceFile *os.File
 
 var traceChan = make(chan string, 8)
 
-func startLogger (file *os.File, fileName string) {
+func startLogger(file *os.File, fileName string) {
 	go func() {
 		for {
 			line := <-traceChan
@@ -76,7 +75,7 @@ func tPrintf(format string, args ...interface{}) {
 		lines := strings.Split(s, "\n")
 		l2 := []string{}
 		for _, l := range lines {
-			l2 = append(l2, t + l + "\n")
+			l2 = append(l2, t+l+"\n")
 		}
 		s = strings.Join(l2, "")
 	}
@@ -99,7 +98,7 @@ func tHeaders(hdrs http.Header, prefix string) string {
 	}
 	sort.Strings(h)
 	for _, m := range h {
-		r = append(r, prefix + m + ": " + strings.Join(hdrs[m], "\n") + "\n")
+		r = append(r, prefix+m+": "+strings.Join(hdrs[m], "\n")+"\n")
 	}
 	return strings.Join(r, "")
 }
@@ -136,12 +135,12 @@ func traceredirectStdoutErr() {
 	Dup2(int(traceFile.Fd()), 2)
 }
 
-func traceOpts(opt string, fn string) (err error)  {
+func traceOpts(opt string, fn string) (err error) {
 	if opt == "" {
 		return
 	}
 	opts := strings.Split(opt, ",")
-	for _, o := range(opts) {
+	for _, o := range opts {
 		switch o {
 		case "webdav":
 			traceOptions |= T_WEBDAV
@@ -170,4 +169,3 @@ func traceOpts(opt string, fn string) (err error)  {
 	}
 	return
 }
-


### PR DESCRIPTION
  Summary

  - Adds a per-handle in-RAM cache with full PUT on close/fsync and inactivity auto-flush.
  - Allows read–write mounts even when the server lacks partial write support.
  - Adds cache_threshold options to bypass RAM cache for large files (when ranged I/O is supported).
  - Improves unmount on signals and process exit.

  Motivation

  - Many WebDAV servers don’t support partial writes, making efficient random I/O hard. This change enables reliable read–write behavior via an in-memory buffer that uploads on close, while
  still using ranged I/O where available and beneficial.

  Key Changes

  - RAM cache handle for reads/writes, PUT on close/fsync, 10s inactivity auto-flush:
      - memhandle.go:1
      - fuse.go:805 (Open), 520 (Create), 572 (ftruncate path for RAM), 281 (Remove local-only), 176 (Rename fast path)
  - Size-based decision: use RAM cache for small files, ranged I/O for large files:
      - fuse.go:829
      - main.go:202 (default 64 MiB)
      - mountoptions.go:9 (CacheThreshold), 87 (cache_threshold), 94 (cache_threshold_mb)
  - Allow mounting and operating without PUT-Range; warn and fallback to RAM cache:
      - main.go:286 (dav.Mount), 202–206, 286–305 (mount + capability messaging)
  - Robust unmount on signals and exit (graceful + lazy detach fallback):
      - main.go:336–359

  New/Updated Options

  - cache_threshold: Size in bytes above which files prefer non‑cached ranged I/O (when available). Default 67108864 (64 MiB).
  - cache_threshold_mb: Same as above, but in MiB.
  - Behavior notes:
      - If the server lacks partial writes, all files use the in‑RAM cache regardless of size.
      - RAM cache auto‑flushes after 10s of inactivity per handle, and on fsync/close.

  Docs

  - README updated with RAM cache mode, auto-flush, options, and behavior:
      - README.md:1
  - DAV requirements expanded with fallback semantics and references:
      - DAV-requirements.md:1

  Behavior Details

  - Open/Create: Loads file into RAM buffer for small files or when no range support; large files use ranged I/O when supported:
      - fuse.go:805, 520, 829
  - Truncate: Resizes in-memory buffer when using RAM handles; otherwise uses PUT/PUT-Range appropriately:
      - fuse.go:572
  - Rename/Delete: Optimized local operations for files not yet uploaded or with open RAM handles:
      - fuse.go:176, 281
  - Unmount: On SIGINT/SIGTERM/SIGHUP, attempts graceful unmount, closes FUSE, falls back to lazy unmount on Linux:
      - main.go:336–359

  Backward Compatibility

  - No breaking changes to existing mounts.
  - Defaults preserve previous ranged-I/O behavior where supported, with a clear default threshold and safe fallback when not.

  Testing Notes

  - Scenarios exercised:
      - Mount against SabreDAV/Apache with partial update support and without.
      - Small file random writes; verify upload on close and after ~10s inactivity.
      - Large file I/O above threshold uses ranged operations.
      - Create with O_EXCL semantics; rename/delete before upload completes.
      - Signal handling triggers unmount and process exit.
  - Example:
      - mount -t webdavfs -o username=...,password=...,cache_threshold_mb=64 https://host/dav /mnt
      - Write small file, keep open >10s to see auto-flush; write large file and observe ranged I/O logs (with -T webdav,httpreq).

  Notes for Reviewers

  - The inactivity timer is per open handle and aims to balance durability vs. overhead.
  - Conditional headers are used on full PUTs to avoid overwriting unexpected states where possible.
  - Default 64 MiB threshold is conservative; can be tuned per environment.

  Checklist

  - [x] Feature: RAM cache, auto-flush, and thresholded I/O
  - [x] Mounting without PUT-Range support
  - [x] Updated docs: README and DAV requirements
  - [x] Manual tests across supported scenarios
  - [ ] Optional: add integration tests against mock DAV endpoints
